### PR TITLE
Change git protocol to https when calling github.com/nextcloud/desktop.git

### DIFF
--- a/init.bat
+++ b/init.bat
@@ -90,7 +90,7 @@ rem 			"nextcloud/desktop"
 Rem ******************************************************************************************
 
 echo "* git clone nextcloud/desktop."
-start "git clone nextcloud/desktop" /D "%PROJECT_PATH%/" /B /wait git clone git://github.com/nextcloud/desktop.git
+start "git clone nextcloud/desktop" /D "%PROJECT_PATH%/" /B /wait git clone https://github.com/nextcloud/desktop.git
 if %ERRORLEVEL% neq 0 goto onError
 
 echo "* Create nextcloud/desktop build directory (recursive)."


### PR DESCRIPTION
Dear Sir,
when launching the init.bat file in a Windows bash shell, the request to download the git://github.com/nextcloud/desktop.git always return an error and the batch stops.
Windows cannot resolve github.com .. changing the git protocol to https the batch works as expected.  

Regards